### PR TITLE
Fixes Multi Pressing Bug

### DIFF
--- a/src/pages/[artist].astro
+++ b/src/pages/[artist].astro
@@ -11,7 +11,7 @@ export async function getStaticPaths() {
   // we're already getting all the artists from getReleasesByArtist
   // We just don't have the artist slug there yet.
   return store.artists.map((artist) => {
-    const artistReleases = allReleases[artist.name];
+    const artistReleases = allReleases[artist.name.toLowerCase()];
 
     return {
       params: { artist: artist.slug },

--- a/src/pages/[artist]/[release].astro
+++ b/src/pages/[artist]/[release].astro
@@ -15,7 +15,7 @@ export async function getStaticPaths() {
     const artist = release.basic_information.artists[0].name;
     const title = release.basic_information.title;
     const id = release.basic_information.id;
-    const otherReleases: Release[] = releases[artist].filter(
+    const otherReleases: Release[] = releases[artist.toLowerCase()].filter(
       (r: Release) => r.basic_information.id !== id
     );
 

--- a/src/pages/[artist]/[release].astro
+++ b/src/pages/[artist]/[release].astro
@@ -13,15 +13,16 @@ export async function getStaticPaths() {
 
   return store.collection.map((release: Release) => {
     const artist = release.basic_information.artists[0].name;
-    const currentTitle = release.basic_information.title;
+    const title = release.basic_information.title;
+    const id = release.basic_information.id;
     const otherReleases: Release[] = releases[artist].filter(
-      (r: Release) => r.basic_information.title !== currentTitle
+      (r: Release) => r.basic_information.id !== id
     );
 
     return {
       params: {
         artist: slug(artist),
-        release: slug(currentTitle),
+        release: `${slug(title)}-${id}`,
       },
       props: { artist, release, otherReleases },
     };

--- a/src/store.ts
+++ b/src/store.ts
@@ -75,12 +75,13 @@ export function getArtists(collection: Release[]): Artist[] {
       const currName = artist.name;
 
       // First check to make sure don't already have this artist in the list
-      if (!artistIndex.includes(currName)) {
+      if (!artistIndex.includes(artist.id)) {
         const next: Artist = {
+          id: artist.id,
           name: currName,
           slug: slug(currName),
         };
-        artistIndex.push(currName);
+        artistIndex.push(artist.id);
         artists.push(next);
       }
     });
@@ -94,7 +95,7 @@ export function getReleasesByArtist(collection: Release[]) {
 
   // Create our object with artist names as keys
   let releases = artists.reduce((obj, artist) => {
-    obj[artist.name] = [];
+    obj[artist.name.toLowerCase()] = [];
     return obj;
   }, {} as { [index: string]: any });
 
@@ -104,7 +105,7 @@ export function getReleasesByArtist(collection: Release[]) {
     .sort((a, b) => a.basic_information.year - b.basic_information.year)
     .forEach((release) => {
       release.basic_information.artists.forEach((artist: any) => {
-        releases[artist.name].push(release);
+        releases[artist.name.toLowerCase()].push(release);
       });
     });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,7 @@ export interface Release {
 export type Collection = Release[];
 
 export interface Artist {
+  id: number;
   name: string;
   slug: string;
 }

--- a/src/util/data.ts
+++ b/src/util/data.ts
@@ -35,8 +35,8 @@ export function sortArtistsByName(list: Artist[]) {
 }
 
 export function getReleaseUrl(release: Release): string {
-  const { title, artists } = release.basic_information;
-  return buildUrl([artists[0].name, title]);
+  const { title, artists, id } = release.basic_information;
+  return buildUrl([artists[0].name, `${title}-${id}`]);
 }
 
 export function getHumanColor(release: Release): string {


### PR DESCRIPTION
Before, each release had a url of `/artist/release-title`, that works for releases that I have a single pressing of, but I have multiple pressings of some records. Different issues, different colors, etc.

This updates the urls of releases to be `/artist/release-title-release-id` ex `/afi/the-art-of-drowning-3310806/`. That way there's always something 100% unique in the url. A slightly less slick of a URL, but works.