### PR TITLE
Adds getArtistDisplayName to fix duplicate artist names

### DIFF
--- a/.astro/settings.json
+++ b/.astro/settings.json
@@ -1,6 +1,6 @@
 {
 	"_variables": {
-		"lastUpdateCheck": 1723967495300
+		"lastUpdateCheck": 1735495175121
 	},
 	"devToolbar": {
 		"enabled": false

--- a/src/components/ReleaseDisplay.astro
+++ b/src/components/ReleaseDisplay.astro
@@ -2,19 +2,20 @@
 import Layout from "@layouts/Layout.astro";
 import ReleaseHero from "@components/ReleaseHero.astro";
 import Releases from "@components/Releases.astro";
-import { buildUrl } from "@util/data";
+import { getArtistDisplayName, buildUrl } from "@util/data";
 
 const { artist, release, otherReleases } = Astro.props;
 const title = release.basic_information.title;
+const artistDisplayName = getArtistDisplayName(artist);
 ---
 
-<Layout title={`${title} by ${artist}`}>
+<Layout title={`${title} by ${artistDisplayName}`}>
   <main class="standard-restricted-width">
     <ReleaseHero artist={artist} release={release} />
 
     <h2 class="standard-page-subtitle">
       {otherReleases.length > 0 ? "More by" : "This is"}
-      <a href={buildUrl([artist])}>{artist}</a>
+      <a href={buildUrl([artist])}>{artistDisplayName}</a>
     </h2>
     {
       otherReleases.length > 0 && (

--- a/src/components/ReleaseHero.astro
+++ b/src/components/ReleaseHero.astro
@@ -6,7 +6,11 @@ export interface props {
 
 import type { Release } from "@types";
 import Vinyl from "@components/Vinyl.astro";
-import { getHumanColor, getMachineColor } from "@util/data";
+import {
+  getHumanColor,
+  getMachineColor,
+  getArtistDisplayName,
+} from "@util/data";
 
 const { artist, release } = Astro.props;
 const { title, cover_image, year } = release.basic_information;
@@ -15,7 +19,9 @@ const { title, cover_image, year } = release.basic_information;
 <div class="container" style={`--machine-color: ${getMachineColor(release)}`}>
   <header>
     <h1 class="title">{title}</h1>
-    <p class="subtitle">{artist} / {year} / {getHumanColor(release)}</p>
+    <p class="subtitle">
+      {getArtistDisplayName(artist)} / {year} / {getHumanColor(release)}
+    </p>
   </header>
   <div class="graphic">
     <div class="disc">

--- a/src/components/Releases.astro
+++ b/src/components/Releases.astro
@@ -6,7 +6,12 @@ export interface Props {
 }
 
 import type { Release } from "@types";
-import { getHumanColor, getMachineColor, getReleaseUrl } from "@util/data";
+import {
+  getArtistDisplayName,
+  getHumanColor,
+  getMachineColor,
+  getReleaseUrl,
+} from "@util/data";
 import Vinyl from "@components/Vinyl.astro";
 
 function getRandomNumber() {
@@ -37,7 +42,9 @@ const { className, releases, showArtist = true } = Astro.props;
             <div class="info">
               <div class="primary-info">
                 <p class="title font-display">{title}</p>
-                {showArtist && <p class="artist">{artists[0].name}</p>}
+                {showArtist && (
+                  <p class="artist">{getArtistDisplayName(artists[0].name)}</p>
+                )}
               </div>
               <p class="desciption">{getHumanColor(release)}</p>
             </div>

--- a/src/pages/[artist].astro
+++ b/src/pages/[artist].astro
@@ -3,6 +3,7 @@ import store from "@store";
 import Layout from "@layouts/Layout.astro";
 import Releases from "@components/Releases.astro";
 import { pluralize } from "@util/string";
+import { getArtistDisplayName } from "@util/data";
 
 export async function getStaticPaths() {
   const allReleases = store.releasesByArtist;
@@ -23,11 +24,11 @@ export async function getStaticPaths() {
 const { artist, releases } = Astro.props;
 ---
 
-<Layout title={artist.name}>
+<Layout title={getArtistDisplayName(artist.name)}>
   <main class="standard-restricted-width">
     <header>
       <h1 class="title">
-        {artist.name}
+        {getArtistDisplayName(artist.name)}
       </h1>
       <h2 class="subtitle">
         {releases.length}

--- a/src/pages/artists.astro
+++ b/src/pages/artists.astro
@@ -1,7 +1,7 @@
 ---
 import store from "@store";
 import Layout from "@layouts/Layout.astro";
-import { buildUrl } from "@util/data";
+import { buildUrl, getArtistDisplayName } from "@util/data";
 
 const artists = store.artists;
 ---
@@ -13,7 +13,7 @@ const artists = store.artists;
       {
         artists.map(({ name }) => (
           <li>
-            <a href={buildUrl([name])}>{name}</a>
+            <a href={buildUrl([name])}>{getArtistDisplayName(name)}</a>
           </li>
         ))
       }

--- a/src/util/data.test.ts
+++ b/src/util/data.test.ts
@@ -1,6 +1,7 @@
 import type { Release } from "@types";
 import { describe, it, expect } from "vitest";
 import {
+  getArtistDisplayName,
   getHumanColor,
   getMachineColor,
   getReleaseUrl,
@@ -129,5 +130,22 @@ describe("getMachineColor function", () => {
     };
 
     expect(getMachineColor(release)).toBe("rgb(100,120,100)");
+  });
+});
+
+describe("getArtistDisplayName function", () => {
+  it("returns cleaned up names when expected", () => {
+    expect(getArtistDisplayName("Battle Royale (2)")).toBe("Battle Royale");
+    expect(getArtistDisplayName("H20 (7)")).toBe("H20");
+    expect(getArtistDisplayName("Pup (3)")).toBe("Pup");
+  });
+
+  it("leaves names alone when expected", () => {
+    expect(getArtistDisplayName("A (strange) Artist Name")).toBe(
+      "A (strange) Artist Name"
+    );
+    expect(getArtistDisplayName("(International) Noise Conspiracy")).toBe(
+      "(International) Noise Conspiracy"
+    );
   });
 });

--- a/src/util/data.ts
+++ b/src/util/data.ts
@@ -70,3 +70,15 @@ export function getMachineColor(release: Release): string {
 
   return color;
 }
+
+/**
+ * In Discogs, if there are duplicate artist names, they append parens and a
+ * number to the name so we end up with some ugly names like; "PUP (2)".
+ * Since we know the do "<original-name> (<number)", this function looks for
+ * that and strips it out so. We only use this for display that way if we do
+ * have duplicate artists, we'll keep the parens and number in place for things
+ * like slugs for URLs and lookups.
+ */
+export function getArtistDisplayName(name: string): string {
+  return name.replace(/\s?\(\d+\)$/, "").trim();
+}


### PR DESCRIPTION
In Discogs, if there are duplicate artist names, they append parens and a number to the name so we end up with some ugly names like; "PUP (2)". Since we know the do "<original-name> (<number)", this function looks for that and strips it out so. We only use this for display that way if we do have duplicate artists, we'll keep the parens and number in place for things like slugs for URLs and lookups.